### PR TITLE
Add multiple choice aliases

### DIFF
--- a/input/flow_definitions/T_survey.json
+++ b/input/flow_definitions/T_survey.json
@@ -199,6 +199,22 @@
       {
         "ID": "unrecognised_response_message",
         "value": "Sorry, I don't understand what you mean."
+      },
+      {
+        "ID": "yes_qr",
+        "value": "Yes"
+      },
+      {
+        "ID": "yes_args",
+        "value": "yes y yeah yep"
+      },
+      {
+        "ID": "no_qr",
+        "value": "No"
+      },
+      {
+        "ID": "no_args",
+        "value": "no nope n"
       }
     ],
     "template_survey_wrapper": [
@@ -3314,8 +3330,26 @@
         "condition": "{{opt.text}}",
         "condition_var": "",
         "condition_type": "has_only_phrase",
-        "condition_name": "",
+        "condition_name": "{{opt.text}}",
         "include_if": "{@opt.text != \"\"@}",
+        "message_text": "{{opt.value}}",
+        "choices": "",
+        "save_name": "variable",
+        "attachments": "",
+        "image": "",
+        "audio": "",
+        "video": ""
+      },
+      {
+        "row_id": "",
+        "type": "save_flow_result",
+        "from": "1",
+        "loop_variable": "",
+        "condition": "{% for a in opt.aliases-%}\n{{a}} {%endfor%}",
+        "condition_var": "",
+        "condition_type": "has_any_word",
+        "condition_name": "{{opt.text}}",
+        "include_if": "{@opt.aliases and opt.aliases|length >0@}",
         "message_text": "{{opt.value}}",
         "choices": "",
         "save_name": "variable",

--- a/input/meta.json
+++ b/input/meta.json
@@ -1,5 +1,5 @@
 {
   "pipeline_version": "1.0.0",
   "config_version": "1.0.6",
-  "pull_timestamp": "2025-08-01 11:06:28.333137+00:00"
+  "pull_timestamp": "2025-09-22 16:15:12.058137+00:00"
 }


### PR DESCRIPTION
In a multiple choice question, added the option to specify a *list* of words that will also be recognised if typed into the chat instead of the actual option displayed as a quick reply